### PR TITLE
Fix wrong item incrementing

### DIFF
--- a/course/13-animations-and-transitions/src/lib/ShoppingCart.svelte
+++ b/course/13-animations-and-transitions/src/lib/ShoppingCart.svelte
@@ -8,12 +8,12 @@
 		cartItems = data;
 	});
 	function addOne(i) {
-		shuffle(i);
 		cartItems[i].quantity = cartItems[i].quantity + 1;
+		shuffle(i);
 	}
 	function removeOne(i) {
-		shuffle(i);
 		cartItems[i].quantity = cartItems[i].quantity - 1;
+		shuffle(i);
 	}
 	let newItem = {
 		name: 'T-Shirt',


### PR DESCRIPTION
When you click on the "+" or "-" button in the shopping cart, the wrong item is modified because shuffle has been called before modifying the item.   Calling the shuffle function after assigning the quantity values fixes this.